### PR TITLE
Do not parse duplicate media queries

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    css_parser (1.6.0)
+    css_parser (1.6.1)
       addressable
 
 GEM
@@ -27,4 +27,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.15.3
+   1.16.2

--- a/lib/css_parser/parser.rb
+++ b/lib/css_parser/parser.rb
@@ -258,7 +258,6 @@ module CssParser
       each_selector(which_media) do |selectors, declarations, specificity, media_types|
         media_types.each do |media_type|
           styles_by_media_types[media_type] ||= []
-          next if styles_by_media_types[media_type].include?([selectors, declarations])
           styles_by_media_types[media_type] << [selectors, declarations]
         end
       end
@@ -377,13 +376,19 @@ module CssParser
             block_depth = block_depth + 1
             in_at_media_rule = false
             in_media_block = true
-            current_media_queries << CssParser.sanitize_media_query(current_media_query)
+            new_media_query = CssParser.sanitize_media_query(current_media_query)
+            if !current_media_queries.include?(new_media_query)
+              current_media_queries << new_media_query
+            end
             current_media_query = ''
           elsif token =~ /[,]/
             # new media query begins
             token.gsub!(/[,]/, ' ')
             current_media_query += token.strip + ' '
-            current_media_queries << CssParser.sanitize_media_query(current_media_query)
+            new_media_query = CssParser.sanitize_media_query(current_media_query)
+            if !current_media_queries.include?(new_media_query)
+              current_media_queries << new_media_query
+            end
             current_media_query = ''
           else
             current_media_query += token.strip + ' '

--- a/lib/css_parser/version.rb
+++ b/lib/css_parser/version.rb
@@ -1,3 +1,3 @@
 module CssParser
-  VERSION = "1.6.0".freeze
+  VERSION = "1.6.1".freeze
 end


### PR DESCRIPTION
Instead of de-duplicating in `to_s`, we can greatly reduce work by not parsing out duplicate media queries.

Same idea as https://github.com/considerhq/css_parser/commit/e9f40bb5a2c5c05d2f9ee4fa389ba4b9ac87eeeb